### PR TITLE
Addressed spelling mistakes, updated READMEs for error analysis module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The table below provides details of the folders and their content.
 | tests | Contains unit tests for core accelerator functionality
 | tsfa/common | Contains Classes that have common helper methods used for data preparation and model training. E.g. `ConfigParser` class that used to parse, get, and set configuration parameters.|
 | tsfa/data_prep | Contains Class and functions for data preparation and data validation, respectively.|
+| tsfa/error_analysis| Contains Class for error analysis for time-series forecasting.|
 | tsfa/evaluation | Evaluator class with functionality to compute model performance metrics such as WMAPE are saved in this folder.|
 | tsfa/feature_engineering | This folder contains the feature engineering utility Classes. The `FeaturesUtils` Class is a "wrapper" class that orchestrates features computations based on specified configuration parameters. |
 | tsfa/models | This folder contains the model utility Classes. The `MultivariateModelWrapper` and `UnivariateModelWrapper` Classes are "wrapper" classes to be used to add new models to the accelerator. |

--- a/notebooks/how_to_use_tsfa/using_ml_experiment_with_error_analysis.py
+++ b/notebooks/how_to_use_tsfa/using_ml_experiment_with_error_analysis.py
@@ -2,7 +2,7 @@
 # MAGIC %md
 # MAGIC # Using the MLExperiment class with Error Analysis
 # MAGIC In this notebook, we demonstrate how to leverage the MLExperiment class and present the capapilites of the Error Analysis class:
-# MAGIC - Plot a distrubtion of the error for key columns
+# MAGIC - Plot a distribution of the error for key columns
 # MAGIC - Plot the error as a function of the time
 # MAGIC - Plot the error as a cohort of the time and the walk number
 # MAGIC - On the experiment side, we show how to:
@@ -147,12 +147,12 @@ myErrorAnalysis.cohort_plot(all_results=all_results, walk_name = 'walk', vmin = 
 # COMMAND ----------
 # MAGIC %md
 
-# MAGIC ### Using the plot hist function to show diffrent distrubtions.
-# MAGIC The plot hist function plots the error distrubtion of the key columns
-# MAGIC Why do we need to plot for diffrent keys combinations?
+# MAGIC ### Using the plot hist function to show different distributions.
+# MAGIC The plot hist function plots the error distribution of the key columns
+# MAGIC Why do we need to plot for different keys combinations?
 # MAGIC When we look only on the store level or the brand level we understand better how to model preforme.
 # MAGIC But we miss some cruicel information, for example, if we have a store that is doing well in the model and we have a brand that is doing well in the model, but when we combine them together we get a bad model.
-# MAGIC Some stores and brands would need diffrent approches, and with the plot hist function we can see it.
+# MAGIC Some stores and brands would need different approches, and with the plot hist function we can see it.
 
 # COMMAND ----------
 

--- a/tsfa/error_analysis/README.md
+++ b/tsfa/error_analysis/README.md
@@ -1,0 +1,7 @@
+# Evaluation
+
+This module provides error analysis capabilities for time series forecasting. Error analysis will assist in understanding the distributions of forecasting performance metrics across cohorts and time.
+
+## error_analysis.py
+
+Implementation of the `ErrorAnalysis` class that can be used to create plots for cohort analysis, and distributions of forecasting performance metrics over time.


### PR DESCRIPTION
This PR adds the missing README.md to the `error_analysis` module, adds a description of the `error_analysis` module to the root README.md and fixes spelling mistakes in the `error_analysis.py` script as well as the `using_ml_experiment_with_error_analysis.py` notebook.